### PR TITLE
RSP-3295 Added Validation for zeros in IRAS ID

### DIFF
--- a/src/Web/Rsp.IrasPortal.Web/Validators/IrasIdViewModelValidator.cs
+++ b/src/Web/Rsp.IrasPortal.Web/Validators/IrasIdViewModelValidator.cs
@@ -16,7 +16,7 @@ public class IrasIdViewModelValidator : AbstractValidator<IrasIdViewModel>
                 .WithMessage("IRAS ID must be 4 to 7 digits")
             .Matches(@"^\d+$")
                 .WithMessage("IRAS ID must only contain numbers")
-            .Must(id => id == null || !id.StartsWith('0'))
+            .Must(id => !id.StartsWith('0'))
                 .WithMessage("IRAS ID cannot start with '0'.");
     }
 }

--- a/src/Web/Rsp.IrasPortal.Web/Validators/IrasIdViewModelValidator.cs
+++ b/src/Web/Rsp.IrasPortal.Web/Validators/IrasIdViewModelValidator.cs
@@ -15,6 +15,8 @@ public class IrasIdViewModelValidator : AbstractValidator<IrasIdViewModel>
             .Length(4, 7)
                 .WithMessage("IRAS ID must be 4 to 7 digits")
             .Matches(@"^\d+$")
-                .WithMessage("IRAS ID must only contain numbers");
+                .WithMessage("IRAS ID must only contain numbers")
+            .Must(id => id == null || !id.StartsWith("0"))
+                .WithMessage("IRAS ID cannot start with '0'.");
     }
 }

--- a/src/Web/Rsp.IrasPortal.Web/Validators/IrasIdViewModelValidator.cs
+++ b/src/Web/Rsp.IrasPortal.Web/Validators/IrasIdViewModelValidator.cs
@@ -17,6 +17,6 @@ public class IrasIdViewModelValidator : AbstractValidator<IrasIdViewModel>
             .Matches(@"^\d+$")
                 .WithMessage("IRAS ID must only contain numbers")
             .Must(id => !id.StartsWith('0'))
-                .WithMessage("IRAS ID cannot start with '0'.");
+                .WithMessage("IRAS ID cannot start with '0'");
     }
 }

--- a/src/Web/Rsp.IrasPortal.Web/Validators/IrasIdViewModelValidator.cs
+++ b/src/Web/Rsp.IrasPortal.Web/Validators/IrasIdViewModelValidator.cs
@@ -16,7 +16,7 @@ public class IrasIdViewModelValidator : AbstractValidator<IrasIdViewModel>
                 .WithMessage("IRAS ID must be 4 to 7 digits")
             .Matches(@"^\d+$")
                 .WithMessage("IRAS ID must only contain numbers")
-            .Must(id => id == null || !id.StartsWith("0"))
+            .Must(id => id == null || !id.StartsWith('0'))
                 .WithMessage("IRAS ID cannot start with '0'.");
     }
 }

--- a/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/Controllers/ApplicationControllerTests/StartProjectTests.cs
+++ b/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/Controllers/ApplicationControllerTests/StartProjectTests.cs
@@ -51,6 +51,28 @@ public class StartProjectTests : TestServiceBase<ApplicationController>
     }
 
     [Fact]
+    public async Task StartProject_ReturnsView_WithModelError_WhenIrasIdStartsWithZero()
+    {
+        // Arrange
+        var model = new IrasIdViewModel { IrasId = "0000" };
+
+        Mocker
+            .GetMock<IValidator<IrasIdViewModel>>()
+            .Setup(v => v.ValidateAsync(It.IsAny<ValidationContext<IrasIdViewModel>>(), default))
+            .ReturnsAsync(new ValidationResult(new List<ValidationFailure>
+            {
+            new ValidationFailure("IrasId", "IRAS ID cannot start with '0'.")
+            }));
+
+        // Act
+        var result = await Sut.StartProject(model);
+
+        // Assert
+        result.ShouldBeOfType<ViewResult>();
+        Sut.ModelState["IrasId"]?.Errors.ShouldContain(e => e.ErrorMessage == "IRAS ID cannot start with '0'.");
+    }
+
+    [Fact]
     public async Task StartProject_ReturnsServiceError_IfGetApplicationsFails()
     {
         // Arrange

--- a/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/Controllers/ApplicationControllerTests/StartProjectTests.cs
+++ b/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/Controllers/ApplicationControllerTests/StartProjectTests.cs
@@ -61,7 +61,7 @@ public class StartProjectTests : TestServiceBase<ApplicationController>
             .Setup(v => v.ValidateAsync(It.IsAny<ValidationContext<IrasIdViewModel>>(), default))
             .ReturnsAsync(new ValidationResult(new List<ValidationFailure>
             {
-            new ValidationFailure("IrasId", "IRAS ID cannot start with '0'.")
+            new ValidationFailure("IrasId", "IRAS ID cannot start with '0'")
             }));
 
         // Act
@@ -69,7 +69,7 @@ public class StartProjectTests : TestServiceBase<ApplicationController>
 
         // Assert
         result.ShouldBeOfType<ViewResult>();
-        Sut.ModelState["IrasId"]?.Errors.ShouldContain(e => e.ErrorMessage == "IRAS ID cannot start with '0'.");
+        Sut.ModelState["IrasId"]?.Errors.ShouldContain(e => e.ErrorMessage == "IRAS ID cannot start with '0'");
     }
 
     [Fact]


### PR DESCRIPTION
## What was the purpose of this ticket?

Add logic to stop users entering an Iras ID starting with an '0'.

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-3304](https://nihr.atlassian.net/browse/RSP-3304)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [] Bug-fix
- [] DevOps
- [] Testing

## Solution

What work was completed to cover off the story?

- Added logic to IrasID Validator to disallow any IRAS ID's starting with a '0'
- Added unit test for above

## Checklist

- [ ] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [ ] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [ ] There are no dead code and no "TODO" comments left
- [ ] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.