### PR TITLE
Review your answers - Typo (capitalisation) fix

### DIFF
--- a/src/Web/Rsp.IrasPortal.Web/Models/QuestionViewModel.cs
+++ b/src/Web/Rsp.IrasPortal.Web/Models/QuestionViewModel.cs
@@ -85,11 +85,15 @@ public class QuestionViewModel
     {
         var label = string.IsNullOrWhiteSpace(ShortQuestionText) ? QuestionText : ShortQuestionText;
 
-        return (!string.IsNullOrWhiteSpace(AnswerText)
-                || Answers.Any(a => a.IsSelected)
-                || (!string.IsNullOrWhiteSpace(SelectedOption) && Answers.Any(a => a.AnswerId == SelectedOption)))
-            ? "Change"
-            : $"Enter {label.ToLowerInvariant()}";
+        var isAnswered = !string.IsNullOrWhiteSpace(AnswerText)
+                     || Answers.Any(a => a.IsSelected)
+                     || (!string.IsNullOrWhiteSpace(SelectedOption) && Answers.Any(a => a.AnswerId == SelectedOption));
+
+        var labelText = label.Contains("NHS / HSC", StringComparison.OrdinalIgnoreCase)
+            ? label
+            : label.ToLowerInvariant();
+
+        return isAnswered ? "Change" : $"Enter {labelText}";
     }
 
     public bool IsMissingAnswer()

--- a/src/Web/Rsp.IrasPortal.Web/Validators/QuestionViewModelValidatorBase.cs
+++ b/src/Web/Rsp.IrasPortal.Web/Validators/QuestionViewModelValidatorBase.cs
@@ -133,6 +133,10 @@ public class QuestionViewModelValidatorBase : AbstractValidator<QuestionViewMode
             ? question.ShortQuestionText
             : question.QuestionText;
 
-        return $"Enter {label.ToLowerInvariant()}";
+        var labelText = label.Contains("NHS / HSC", StringComparison.OrdinalIgnoreCase)
+            ? label
+            : label.ToLowerInvariant();
+
+        return $"Enter {labelText}";
     }
 }


### PR DESCRIPTION
## What was the purpose of this ticket?
Text next to the field ‘NHS / HSC organisations’ states ‘Enter NHS / HSC organisations’

## Jira Ref
[RSP-3425](https://nihr.atlassian.net/browse/RSP-3425)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [x] Bug-fix
- [] DevOps
- [] Testing

## Solution

What work was completed to cover off the story?

- List out changes made to the repo

## Checklist

- [ ] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [ ] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [ ] There are no dead code and no "TODO" comments left
- [ ] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.