### PR TITLE
Project Overview - title and caption font change bugfix

### DIFF
--- a/src/Web/Rsp.IrasPortal.Web/Views/Application/ProjectOverview.cshtml
+++ b/src/Web/Rsp.IrasPortal.Web/Views/Application/ProjectOverview.cshtml
@@ -4,8 +4,8 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-		<h1 class="govuk-heading-xl">
-			<span class="govuk-caption-xl">@Model.ProjectTitle</span>
+		<h1 class="govuk-heading-l">
+			<span class="govuk-caption-l">@Model.ProjectTitle</span>
 			Project overview
 		</h1>
     </div>


### PR DESCRIPTION
## What was the purpose of this ticket?

Project overview to be 36px, not 48px.
short project title to be 24px, not 27px.

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-3325](https://nihr.atlassian.net/browse/RSP-3325)

## Type of Change

Put [X] inside the [] to make the box ticked

- [ ] New feature
- [ ] Refactoring
- [x] Bug-fix
- [ ] DevOps
- [ ] Testing

## Solution

What work was completed to cover off the story?

In Project Overview view, govuk-heading-xl of title and caption title, changed to govuk-heading-l to facilitate changes expected.

## Checklist

- [x] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [x] You are using the correct naming conventions
- [x] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [x] There are no dead code and no "TODO" comments left
- [x] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.