### PR TITLE
RSP-3519: Remove 'Manage users' and 'System Admin' from navbar

### DIFF
--- a/src/Web/Rsp.IrasPortal.Web/Views/Shared/_Layout.cshtml
+++ b/src/Web/Rsp.IrasPortal.Web/Views/Shared/_Layout.cshtml
@@ -87,30 +87,11 @@
                             </authorized>
                         </feature>
 
-                        <feature name="@Features.Admin">
-                            <authorized auth-params="@new()">
-                                <li class="govuk-service-navigation__item @(active == "manageUsers" ? "govuk-service-navigation__item--active" : "" )">
-                                    <a class="govuk-service-navigation__link"
-                                       asp-route="admin:users">
-                                        Manage Users
-                                    </a>
-                                </li>
-                            </authorized>
-                        </feature>
-
                         <authorized auth-params="@new(Roles:"admin")">
                             <li class="govuk-service-navigation__item">
                                 <a class="govuk-service-navigation__link"
                                    asp-route="qsc:index">
                                     Question Set
-                                </a>
-                            </li>
-                        </authorized>
-                        <authorized auth-params="@new(Roles:"admin")">
-                            <li class="govuk-service-navigation__item">
-                                <a class="govuk-service-navigation__link"
-                                   asp-route="systemadmin:view">
-                                    System Admin
                                 </a>
                             </li>
                         </authorized>


### PR DESCRIPTION
## What was the purpose of this ticket?

Remove 'Manage users' and 'System Admin' from navbar

## Jira Ref

[RSP-3519](https://nihr.atlassian.net/browse/RSP-3519)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [x] Refactoring
- [] Bug-fix
- [] DevOps
- [] Testing

## Checklist

- [x] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [x] You are using the correct naming conventions
- [x] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [x] There are no dead code and no "TODO" comments left
- [x] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.