### PR TITLE
RSP-3294-2 when characters in telephone show only contain numbers

### DIFF
--- a/src/Web/Rsp.IrasPortal.Web/Validators/UserInfoValidator.cs
+++ b/src/Web/Rsp.IrasPortal.Web/Validators/UserInfoValidator.cs
@@ -12,6 +12,7 @@ public class UserInfoValidator : AbstractValidator<UserViewModel>
     private const string TitleMaxCharactersErrorMessage = "Title must be 250 characters or less";
     private const string EmailMaxCharactersErrorMessage = "Email address must be 250 characters or less";
     private const string TelephoneMaxCharactersErrorMessage = "Telephone must be 11 digits or less";
+    private const string TelephoneNotDigitMessage = "Telephone must only contain numbers";
     private const string FirstNameMandatoryErrorMessage = "Enter a first name";
     private const string LastNameMandatoryErrorMessage = "Enter a last name";
     private const string EmailFormatErrorMessage = "Enter an email address in the correct format";
@@ -52,7 +53,7 @@ public class UserInfoValidator : AbstractValidator<UserViewModel>
             .WithMessage(TelephoneMaxCharactersErrorMessage)
             .Must(x => x.All(char.IsDigit))
             .When(x => !string.IsNullOrEmpty(x.Telephone))
-            .WithMessage(TelephoneMaxCharactersErrorMessage);
+            .WithMessage(TelephoneNotDigitMessage);
 
         RuleFor(x => x.Organisation)
             .MaximumLength(250)

--- a/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/Validators/UserInfoValidatortests/ValidateAsyncTests.cs
+++ b/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/Validators/UserInfoValidatortests/ValidateAsyncTests.cs
@@ -33,7 +33,27 @@ public class ValidateAsyncTests : TestServiceBase<UserInfoValidator>
         {
             FirstName = "Hello",
             LastName = "Ham",
-            Telephone = "qwerty"
+            Telephone = "qwertyuiopa"
+        };
+
+        // Act
+        var result = await Sut.TestValidateAsync(model);
+
+        // Assert
+        result
+            .ShouldHaveValidationErrorFor(x => x.Telephone)
+            .WithErrorMessage("Telephone must only contain numbers");
+    }
+
+    [Fact]
+    public async Task ShouldHaveValidationErrorForTelephone11DigitOrMore()
+    {
+        // Arrange
+        var model = new UserViewModel
+        {
+            FirstName = "Hello",
+            LastName = "Ham",
+            Telephone = "078987654323"
         };
 
         // Act


### PR DESCRIPTION
## What was the purpose of this ticket?
When characters are in telephone field it only shows "must contain numbers."
When characters are in telephone field it only shows  and 12 more digits "must contain numbers and 11 digits or less".
When more than 11 digits "11 digits or less".
Provide a brief description of the ticket

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-3294](https://nihr.atlassian.net/browse/RSP-3294)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [X] Bug-fix
- [] DevOps
- [] Testing

## Solution

What work was completed to cover off the story?

- Changed the text that showed the logic existed already from previous PR.

## Checklist

- [X] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [X] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [ ] There are no dead code and no "TODO" comments left
- [ ] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.