### PR TITLE
Lift the MVC model-binding collection cap (default is 1024)

### DIFF
--- a/src/Startup/Rsp.IrasPortal/Program.cs
+++ b/src/Startup/Rsp.IrasPortal/Program.cs
@@ -2,6 +2,7 @@
 using Mapster;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.FeatureManagement;
@@ -101,6 +102,9 @@ services
         options.Filters.Add<ModelStateMergeAttribute>();
     })
     .AddSessionStateTempDataProvider();
+
+// Lift the MVC model-binding collection cap (default is 1024)
+services.Configure<MvcOptions>(o => o.MaxModelBindingCollectionSize = int.MaxValue);
 
 services.Configure<HealthCheckPublisherOptions>(options => options.Period = TimeSpan.FromSeconds(300));
 


### PR DESCRIPTION
## What was the purpose of this ticket?

Lift the MVC model-binding collection cap

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-###](https://nihr.atlassian.net/browse/RSP-###)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [] Bug-fix
- [] DevOps
- [] Testing

## Solution

What work was completed to cover off the story?

- List out changes made to the repo

## Checklist

- [ ] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [ ] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [ ] There are no dead code and no "TODO" comments left
- [ ] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.