### PR TITLE
RSP-4381 Retain the applied filters when switching between pages

### DIFF
--- a/src/Application/Rsp.IrasPortal.Application/Constants/SessionKeys.cs
+++ b/src/Application/Rsp.IrasPortal.Application/Constants/SessionKeys.cs
@@ -12,4 +12,7 @@ public static class SessionKeys
     public const string FirstLogin = "session:first_login";
     public const string Alive = "session:alive";
     public const string ApprovalsSearch = "session:approvalssearch";
+    public const string UsersSearch = "session:userssearch";
+    public const string ReviewBodiesSearch = "session:reviewbodiessearch";
+    public const string ModificationsTasklist = "session:modificationstasklist";
 }

--- a/src/Application/Rsp.IrasPortal.Application/Constants/TempDataKeys.cs
+++ b/src/Application/Rsp.IrasPortal.Application/Constants/TempDataKeys.cs
@@ -50,7 +50,6 @@ public struct TempDataKeys
     public const string OrgSearchReturnUrl = "td:org_search_return_url";
     public const string ModelState = "td:model_state";
     public const string ShowNotificationBanner = "td:show_notification_banner";
-    public const string ApprovalsSearchModel = "td:approvalsSearchModel";
     public const string OrganisationSearchModel = "td:organisationSearchModel";
     public const string Status = "td:status";
 }

--- a/src/Web/Rsp.IrasPortal.Web/ActionFilters/AdvancedFiltersSessionFilter.cs
+++ b/src/Web/Rsp.IrasPortal.Web/ActionFilters/AdvancedFiltersSessionFilter.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Rsp.IrasPortal.Web.ActionFilters;
+
+public sealed class AdvancedFiltersSessionFilter : IActionFilter
+{
+    private readonly Dictionary<string, string[]> _controllerSessionMap;
+
+    /// <summary>
+    ///     Clears advanced filter session keys when navigating outside mapped controllers.
+    /// </summary>
+    public AdvancedFiltersSessionFilter(Dictionary<string, string[]> controllerSessionMap)
+    {
+        _controllerSessionMap = controllerSessionMap ?? [];
+    }
+
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+        var controller = context.ActionDescriptor is ControllerActionDescriptor cad
+            ? cad.ControllerName
+            : context.RouteData.Values["controller"]?.ToString();
+
+        if (controller == null)
+        {
+            return;
+        }
+
+        // If the current controller has mappings, do nothing
+        if (_controllerSessionMap.ContainsKey(controller))
+        {
+            return;
+        }
+
+        // Otherwise, clear all registered filter session keys
+        foreach (var kv in _controllerSessionMap.Values)
+        {
+            foreach (var key in kv)
+            {
+                context.HttpContext.Session.Remove(key);
+            }
+        }
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+    }
+}

--- a/tests/UnitTests/Rsp.IrasPortal.UnitTests/InMemorySession.cs
+++ b/tests/UnitTests/Rsp.IrasPortal.UnitTests/InMemorySession.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Rsp.IrasPortal.UnitTests;
+
+/// <summary>
+///     Minimal in-memory ISession implementation for unit tests.
+///     Works with SessionExtensions SetString/GetString.
+/// </summary>
+public sealed class InMemorySession : ISession
+{
+    private readonly Dictionary<string, byte[]> _store = new();
+
+    public bool IsAvailable => true;
+    public string Id { get; } = Guid.NewGuid().ToString();
+    public IEnumerable<string> Keys => _store.Keys;
+
+    public void Clear()
+    {
+        _store.Clear();
+    }
+
+    public Task CommitAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task LoadAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public void Remove(string key)
+    {
+        _store.Remove(key);
+    }
+
+    public void Set(string key, byte[] value)
+    {
+        _store[key] = value;
+    }
+
+    public bool TryGetValue(string key, out byte[] value)
+    {
+        return _store.TryGetValue(key, out value);
+    }
+}

--- a/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/AdvancedFilters/AdvancedFiltersSessionFilterTests.cs
+++ b/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/AdvancedFilters/AdvancedFiltersSessionFilterTests.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Rsp.IrasPortal.Web.ActionFilters;
+
+namespace Rsp.IrasPortal.UnitTests.Web.AdvancedFilters;
+
+public class AdvancedFiltersSessionFilterTests
+{
+    private static ActionExecutingContext MakeContext(string? controllerName, ISession session)
+    {
+        var http = new DefaultHttpContext { Session = session };
+
+        var descriptor =
+            controllerName is null
+                ? new ActionDescriptor() // no controller info; will hit controller == null branch
+                : new ControllerActionDescriptor { ControllerName = controllerName };
+
+        var actionContext = new ActionContext(http, new RouteData(), descriptor);
+        return new ActionExecutingContext(
+            actionContext,
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object?>(),
+            null
+        );
+    }
+
+    [Fact]
+    public void Clears_registered_keys_when_navigating_outside_mapped_controllers()
+    {
+        // arrange
+        var map = new Dictionary<string, string[]>
+        {
+            ["Approvals"] = new[] { "session:ApprovalsSearch", "session:Tasklist" },
+            ["Users"] = new[] { "session:UserSearch" }
+        };
+
+        var session = new InMemorySession();
+        session.SetString("session:ApprovalsSearch", "x");
+        session.SetString("session:Tasklist", "y");
+        session.SetString("session:UserSearch", "z");
+        session.SetString("session:Unrelated", "keep"); // should never be cleared
+
+        var ctx = MakeContext("Home", session); // "Home" is NOT in map => should clear
+
+        var filter = new AdvancedFiltersSessionFilter(map);
+
+        // act
+        filter.OnActionExecuting(ctx);
+
+        // assert
+        session.Keys.ShouldNotContain("session:ApprovalsSearch");
+        session.Keys.ShouldNotContain("session:Tasklist");
+        session.Keys.ShouldNotContain("session:UserSearch");
+        session.Keys.ShouldContain("session:Unrelated"); // untouched
+    }
+
+    [Fact]
+    public void Does_not_clear_when_current_controller_is_mapped()
+    {
+        // arrange
+        var map = new Dictionary<string, string[]>
+        {
+            ["Approvals"] = new[] { "session:ApprovalsSearch", "session:Tasklist" }
+        };
+
+        var session = new InMemorySession();
+        session.SetString("session:ApprovalsSearch", "x");
+        session.SetString("session:Tasklist", "y");
+
+        var ctx = MakeContext("Approvals", session); // mapped controller
+
+        var filter = new AdvancedFiltersSessionFilter(map);
+
+        // act
+        filter.OnActionExecuting(ctx);
+
+        // assert (nothing cleared)
+        session.Keys.ShouldContain("session:ApprovalsSearch");
+        session.Keys.ShouldContain("session:Tasklist");
+    }
+
+    [Fact]
+    public void Noop_when_controller_is_unknown()
+    {
+        // arrange
+        var map = new Dictionary<string, string[]>
+        {
+            ["Approvals"] = new[] { "session:ApprovalsSearch" }
+        };
+
+        var session = new InMemorySession();
+        session.SetString("session:ApprovalsSearch", "x");
+
+        var ctx = MakeContext(null, session); // ActionDescriptor without controller info
+
+        var filter = new AdvancedFiltersSessionFilter(map);
+
+        // act
+        filter.OnActionExecuting(ctx);
+
+        // assert (unchanged)
+        session.Keys.ShouldContain("session:ApprovalsSearch");
+    }
+}

--- a/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/Controllers/ModificationsTasklistControllerTests/RemoveFilterTests.cs
+++ b/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/Controllers/ModificationsTasklistControllerTests/RemoveFilterTests.cs
@@ -3,7 +3,6 @@ using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Rsp.IrasPortal.Application.Constants;
 using Rsp.IrasPortal.Web.Controllers;
 using Rsp.IrasPortal.Web.Models;
@@ -12,23 +11,28 @@ namespace Rsp.IrasPortal.UnitTests.Web.Controllers.ModificationsTasklistControll
 
 public class RemoveFiltersTests : TestServiceBase<ModificationsTasklistController>
 {
+    private readonly DefaultHttpContext _http;
+
+    public RemoveFiltersTests()
+    {
+        _http = new DefaultHttpContext { Session = new InMemorySession() };
+        Sut.ControllerContext = new ControllerContext { HttpContext = _http };
+
+        // Default validator OK unless a test overrides it
+        SetupValidValidator();
+    }
+
     [Fact]
     public async Task RemoveFilter_ProjectTitle_ShouldBeCleared_AndRedirect()
     {
         var model = new ApprovalsSearchModel { ShortProjectTitle = "Cancer Study" };
-        SetTempData(new Dictionary<string, object?>
-        {
-            { TempDataKeys.ApprovalsSearchModel, JsonSerializer.Serialize(model) }
-        });
-        SetupValidValidator();
+        SetSessionModel(model);
 
         var result = await Sut.RemoveFilter("shortprojecttitle");
 
         result.ShouldBeOfType<RedirectToActionResult>().ActionName.ShouldBe("Index");
 
-        var updated =
-            JsonSerializer.Deserialize<ApprovalsSearchModel>(
-                Sut.TempData[TempDataKeys.ApprovalsSearchModel]!.ToString()!)!;
+        var updated = GetSessionModel();
         updated.ShortProjectTitle.ShouldBeNull();
     }
 
@@ -36,19 +40,13 @@ public class RemoveFiltersTests : TestServiceBase<ModificationsTasklistControlle
     public async Task RemoveFilter_FromDate_ShouldBeCleared_AndRedirect()
     {
         var model = new ApprovalsSearchModel { FromDay = "01", FromMonth = "01", FromYear = "2023" };
-        SetTempData(new Dictionary<string, object?>
-        {
-            { TempDataKeys.ApprovalsSearchModel, JsonSerializer.Serialize(model) }
-        });
-        SetupValidValidator();
+        SetSessionModel(model);
 
         var result = await Sut.RemoveFilter("datesubmitted-from");
 
         result.ShouldBeOfType<RedirectToActionResult>().ActionName.ShouldBe("Index");
 
-        var updated =
-            JsonSerializer.Deserialize<ApprovalsSearchModel>(
-                Sut.TempData[TempDataKeys.ApprovalsSearchModel]!.ToString()!)!;
+        var updated = GetSessionModel();
         updated.FromDay.ShouldBeNull();
         updated.FromMonth.ShouldBeNull();
         updated.FromYear.ShouldBeNull();
@@ -58,42 +56,40 @@ public class RemoveFiltersTests : TestServiceBase<ModificationsTasklistControlle
     public async Task RemoveFilter_ToDate_ShouldBeCleared_AndRedirect()
     {
         var model = new ApprovalsSearchModel { ToDay = "31", ToMonth = "12", ToYear = "2023" };
-        SetTempData(new Dictionary<string, object?>
-        {
-            { TempDataKeys.ApprovalsSearchModel, JsonSerializer.Serialize(model) }
-        });
-        SetupValidValidator();
+        SetSessionModel(model);
 
         var result = await Sut.RemoveFilter("datesubmitted-to");
 
         result.ShouldBeOfType<RedirectToActionResult>().ActionName.ShouldBe("Index");
 
-        var updated =
-            JsonSerializer.Deserialize<ApprovalsSearchModel>(
-                Sut.TempData[TempDataKeys.ApprovalsSearchModel]!.ToString()!)!;
+        var updated = GetSessionModel();
         updated.ToDay.ShouldBeNull();
         updated.ToMonth.ShouldBeNull();
         updated.ToYear.ShouldBeNull();
     }
 
-
     [Fact]
     public async Task RemoveFilter_FromAndToDate_ShouldBeCleared_AndRedirect()
     {
-        var model = new ApprovalsSearchModel { FromDay = "01", FromMonth = "01", FromYear = "2023",ToDay = "31", ToMonth = "12", ToYear = "2026" };
-        SetTempData(new Dictionary<string, object?>
+        var model = new ApprovalsSearchModel
         {
-            { TempDataKeys.ApprovalsSearchModel, JsonSerializer.Serialize(model) }
-        });
-        SetupValidValidator();
+            FromDay = "01",
+            FromMonth = "01",
+            FromYear = "2023",
+            ToDay = "31",
+            ToMonth = "12",
+            ToYear = "2026"
+        };
+        SetSessionModel(model);
 
         var result = await Sut.RemoveFilter("datesubmitted");
 
         result.ShouldBeOfType<RedirectToActionResult>().ActionName.ShouldBe("Index");
 
-        var updated =
-            JsonSerializer.Deserialize<ApprovalsSearchModel>(
-                Sut.TempData[TempDataKeys.ApprovalsSearchModel]!.ToString()!)!;
+        var updated = GetSessionModel();
+        updated.FromDay.ShouldBeNull();
+        updated.FromMonth.ShouldBeNull();
+        updated.FromYear.ShouldBeNull();
         updated.ToDay.ShouldBeNull();
         updated.ToMonth.ShouldBeNull();
         updated.ToYear.ShouldBeNull();
@@ -103,58 +99,44 @@ public class RemoveFiltersTests : TestServiceBase<ModificationsTasklistControlle
     public async Task RemoveFilter_DaysSinceSubmissionFrom_ShouldBeCleared_AndRedirect()
     {
         var model = new ApprovalsSearchModel { FromDaysSinceSubmission = "01" };
-        SetTempData(new Dictionary<string, object?>
-        {
-            { TempDataKeys.ApprovalsSearchModel, JsonSerializer.Serialize(model) }
-        });
-        SetupValidValidator();
+        SetSessionModel(model);
 
         var result = await Sut.RemoveFilter("dayssincesubmission-from");
 
         result.ShouldBeOfType<RedirectToActionResult>().ActionName.ShouldBe("Index");
 
-        var updated =
-            JsonSerializer.Deserialize<ApprovalsSearchModel>(
-                Sut.TempData[TempDataKeys.ApprovalsSearchModel]!.ToString()!)!;
-        updated.ToDay.ShouldBeNull();
-        updated.ToMonth.ShouldBeNull();
-        updated.ToYear.ShouldBeNull();
+        var updated = GetSessionModel();
+        updated.FromDaysSinceSubmission.ShouldBeNull();
     }
-
 
     [Fact]
     public async Task RemoveFilter_DaysSinceSubmissionTo_ShouldBeCleared_AndRedirect()
     {
-        var model = new ApprovalsSearchModel { FromDaysSinceSubmission = "01" };
-        SetTempData(new Dictionary<string, object?>
-        {
-            { TempDataKeys.ApprovalsSearchModel, JsonSerializer.Serialize(model) }
-        });
-        SetupValidValidator();
+        var model = new ApprovalsSearchModel { ToDaysSinceSubmission = "10" };
+        SetSessionModel(model);
 
         var result = await Sut.RemoveFilter("dayssincesubmission-to");
 
         result.ShouldBeOfType<RedirectToActionResult>().ActionName.ShouldBe("Index");
 
-        var updated =
-            JsonSerializer.Deserialize<ApprovalsSearchModel>(
-                Sut.TempData[TempDataKeys.ApprovalsSearchModel]!.ToString()!)!;
-        updated.ToDay.ShouldBeNull();
-        updated.ToMonth.ShouldBeNull();
-        updated.ToYear.ShouldBeNull();
+        var updated = GetSessionModel();
+        updated.ToDaysSinceSubmission.ShouldBeNull();
     }
 
-    private void SetTempData(IDictionary<string, object?> values)
+    // ----------------------
+    // Helpers
+    // ----------------------
+
+    private void SetSessionModel(ApprovalsSearchModel model)
     {
-        var httpContext = new DefaultHttpContext();
-        var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
+        _http.Session.SetString(SessionKeys.ModificationsTasklist, JsonSerializer.Serialize(model));
+    }
 
-        foreach (var kvp in values)
-        {
-            tempData[kvp.Key] = kvp.Value;
-        }
-
-        Sut.TempData = tempData;
+    private ApprovalsSearchModel GetSessionModel()
+    {
+        var json = _http.Session.GetString(SessionKeys.ModificationsTasklist);
+        json.ShouldNotBeNullOrWhiteSpace();
+        return JsonSerializer.Deserialize<ApprovalsSearchModel>(json!)!;
     }
 
     private void SetupValidValidator()

--- a/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/Controllers/ReviewBodyControllerTests/ClearFiltersTests.cs
+++ b/tests/UnitTests/Rsp.IrasPortal.UnitTests/Web/Controllers/ReviewBodyControllerTests/ClearFiltersTests.cs
@@ -1,12 +1,27 @@
 ﻿using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Rsp.IrasPortal.UnitTests;
 using Rsp.IrasPortal.Web.Controllers;
 using Rsp.IrasPortal.Web.Models;
 
-namespace Rsp.IrasPortal.UnitTests.Web.Controllers.ReviewBodyControllerTests;
-
 public class ClearFiltersTests : TestServiceBase<ReviewBodyController>
 {
+    private readonly DefaultHttpContext _http;
+
+    public ClearFiltersTests()
+    {
+        _http = new DefaultHttpContext
+        {
+            Session = new InMemorySession()
+        };
+
+        Sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = _http
+        };
+    }
+
     [Fact]
     public void ClearFilters_WithoutSearchQuery_ShouldRedirectWithEmptySearch()
     {


### PR DESCRIPTION
## What was the purpose of this ticket?

Retain the applied filters when switching between pages

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-4381](https://nihr.atlassian.net/browse/RSP-4381)

## Type of Change

Put [X] inside the [] to make the box ticked

- [x] New feature
- [] Refactoring
- [] Bug-fix
- [] DevOps
- [] Testing

## Solution

What work was completed to cover off the story?

- List out changes made to the repo

## Checklist

- [ ] Your code builds clean without any  warnings
- [x] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [ ] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [ ] There are no dead code and no "TODO" comments left
- [ ] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.