### PR TITLE
RSP-5004 Review Body Audit Trail duplicates entries after 2 full pages

### DIFF
--- a/src/Web/Rsp.IrasPortal.Web/Controllers/ReviewBodyController.cs
+++ b/src/Web/Rsp.IrasPortal.Web/Controllers/ReviewBodyController.cs
@@ -363,8 +363,7 @@ public class ReviewBodyController(
     public async Task<IActionResult> AuditTrail(Guid reviewBodyId, int pageNumber = 1, int pageSize = 20)
     {
         var skip = (pageNumber - 1) * pageSize;
-        var take = pageNumber * pageSize;
-        var response = await reviewBodyService.ReviewBodyAuditTrail(reviewBodyId, skip, take);
+        var response = await reviewBodyService.ReviewBodyAuditTrail(reviewBodyId, skip, pageSize);
 
         var auditTrailResponse = response?.Content;
         var items = auditTrailResponse?.Items;


### PR DESCRIPTION
## What was the purpose of this ticket?

RSP-5004 Review Body Audit Trail duplicates entries after 2 full pages

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-5004](https://nihr.atlassian.net/browse/RSP-5004)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [X] Bug-fix
- [] DevOps
- [] Testing

## Solution

What work was completed to cover off the story?

- List out changes made to the repo

## Checklist

- [ ] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [ ] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [ ] There are no dead code and no "TODO" comments left
- [ ] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.