### PR TITLE
RSP-5032 Manage Users & Review bodies -Applying a sort clears the current search and selected filters

### DIFF
--- a/src/Web/Rsp.IrasPortal.Web/Controllers/ReviewBodyController.cs
+++ b/src/Web/Rsp.IrasPortal.Web/Controllers/ReviewBodyController.cs
@@ -115,12 +115,15 @@ public class ReviewBodyController(
         [FromQuery] bool fromPagination = false)
     {
         // Always attempt to restore from session if nothing is currently set
-        var savedSearch = HttpContext.Session.GetString(SessionKeys.ReviewBodiesSearch);
-        if (!string.IsNullOrWhiteSpace(savedSearch))
+        if (HttpContext.Request.Method == HttpMethods.Get)
         {
-            model.Search = JsonSerializer.Deserialize<ReviewBodySearchModel>(savedSearch);
+            var savedSearch = HttpContext.Session.GetString(SessionKeys.ReviewBodiesSearch);
+            if (!string.IsNullOrWhiteSpace(savedSearch))
+            {
+                model.Search = JsonSerializer.Deserialize<ReviewBodySearchModel>(savedSearch);
+            }
         }
-
+  
         // Call Index with matching parameter set
         return await ViewReviewBodies(
             1, // pageNumber


### PR DESCRIPTION
## What was the purpose of this ticket?

Provide a brief description of the ticket

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-5032](https://nihr.atlassian.net/browse/RSP-5032)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [X] Bug-fix
- [] DevOps
- [] Testing

## Solution

What work was completed to cover off the story?

- List out changes made to the repo

## Checklist

- [ ] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [ ] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [ ] There are no dead code and no "TODO" comments left
- [ ] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.